### PR TITLE
Update instructions to reflect new tag format in WSL kernel repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,30 +50,30 @@ Install prerequisites to build Linux kernel:
 Find out the name of your Linux kernel:
 ```
 ~$ uname -r
-4.19.43-microsoft-standard
+4.19.79-microsoft-standard
 ```
 
 Clone the WSL 2 kernel. Typically kernel source is put in /usr/src/[kernel name]:
 ```
-~$ sudo git clone https://github.com/microsoft/WSL2-Linux-Kernel.git /usr/src/4.19.43-microsoft-standard
-~$ cd /usr/src/4.19.43-microsoft-standard
+~$ sudo git clone https://github.com/microsoft/WSL2-Linux-Kernel.git /usr/src/4.19.79-microsoft-standard
+~$ cd /usr/src/4.19.79-microsoft-standard
 ```
 
 Checkout your version of the kernel:
 ```
-/usr/src/4.19.43-microsoft-standard$ sudo git checkout v4.19.43
+/usr/src/4.19.79-microsoft-standard$ sudo git checkout 4.19.79-microsoft-standard
 ```
 
 Copy in your current kernel configuration:
 ```
-/usr/src/4.19.43-microsoft-standard$ sudo cp /proc/config.gz config.gz
-/usr/src/4.19.43-microsoft-standard$ sudo gunzip config.gz
-/usr/src/4.19.43-microsoft-standard$ sudo mv config .config
+/usr/src/4.19.79-microsoft-standard$ sudo cp /proc/config.gz config.gz
+/usr/src/4.19.79-microsoft-standard$ sudo gunzip config.gz
+/usr/src/4.19.79-microsoft-standard$ sudo mv config .config
 ```
 
 Run menuconfig to select what kernel modules you'd like to add:
 ```
-/usr/src/4.19.43-microsoft-standard$ sudo make menuconfig
+/usr/src/4.19.79-microsoft-standard$ sudo make menuconfig
 ```
 
 Navigate in menuconfig to select the USB kernel modules you'd like. These suited my needs but add more or less as you see fit:
@@ -99,7 +99,7 @@ Device Drivers->Network device support->USB Network Adapters->Multi-purpose USB 
 
 Build the kernel and modules with as many cores as you have available (-j [number of cores]). This may take a few minutes depending how fast your machine is:
 ```
-/usr/src/4.19.43-microsoft-standard$ sudo make -j 12 && sudo make modules_install -j 12 && sudo make install -j 12
+/usr/src/4.19.79-microsoft-standard$ sudo make -j 12 && sudo make modules_install -j 12 && sudo make install -j 12
 ```
 
 After the build completes you'll get a list of what kernel modules have been installed. Mine looks like:
@@ -120,20 +120,20 @@ After the build completes you'll get a list of what kernel modules have been ins
   INSTALL drivers/usb/storage/usb-storage.ko
   INSTALL drivers/usb/usbip/usbip-core.ko
   INSTALL drivers/usb/usbip/vhci-hcd.ko
-  DEPMOD  4.19.43-microsoft-standard
+  DEPMOD  4.19.79-microsoft-standard
 ```
 
 Build USBIP tools:
 ```
-/usr/src/4.19.43-microsoft-standard$ cd tools/usb/usbip
-/usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo ./autogen.sh
-/usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo ./configure
-/usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo make install -j 12
+/usr/src/4.19.79-microsoft-standard$ cd tools/usb/usbip
+/usr/src/4.19.79-microsoft-standard/tools/usb/usbip$ sudo ./autogen.sh
+/usr/src/4.19.79-microsoft-standard/tools/usb/usbip$ sudo ./configure
+/usr/src/4.19.79-microsoft-standard/tools/usb/usbip$ sudo make install -j 12
 ```
 
 Copy USBIP tools libraries to location that USBIP tools can get to them:
 ```
-/usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo cp libsrc/.libs/libusbip.so.0 /lib/libusbip.so.0
+/usr/src/4.19.79-microsoft-standard/tools/usb/usbip$ sudo cp libsrc/.libs/libusbip.so.0 /lib/libusbip.so.0
 ````
 
 Make a script in your home directory to modprobe in all the drivers. Be sure to modprobe in usbcore and usb-common first. I called mine startusb.sh. Mine looks like:


### PR DESCRIPTION
Tag format in wsl2 kernel repo has changed from vx.yy.zz to x.yy.zz-microsoft-standard.