### PR TITLE
Add patch section for USB/IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Update sources:
 Install prerequisites to build Linux kernel:
 ```
 ~$ sudo apt install build-essential flex bison libssl-dev libelf-dev libncurses-dev autoconf libudev-dev libtool
-````
+```
 
 Find out the name of your Linux kernel:
 ```
@@ -131,7 +131,7 @@ Build USBIP tools:
 /usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo make install -j 12
 ```
 
-New [warnings](https://gcc.gnu.org/gcc-9/changes.html#c-family) were introduced in gcc 9, which can cause the USB/IP build to faild. Their causes can be patched using:
+New [warnings](https://gcc.gnu.org/gcc-9/changes.html#c-family) were introduced in gcc 9, which can cause the USB/IP build to fail. Their causes can be patched using:
 1. `stringop-truncation`
 
     Message:
@@ -152,10 +152,28 @@ New [warnings](https://gcc.gnu.org/gcc-9/changes.html#c-family) were introduced 
              |                                ^~~~~~~~~~~~~
     [Patch](https://sources.debian.org/src/linux/5.4.19-1/debian/patches/bugfix/all/usbip-network-fix-unaligned-member-access.patch/)
 
+__Recommended__: To patch, you can use the script in the [`./scripts`](./scripts) directory: [`apply_patches.sh`](./scripts/apply_patches.sh).
+
+By default, the script applies the patches found in [`./patches`](./patches) to `/usr/src/*microsoft-standard`.
+If your kernel source code is checked out to `/usr/src/*microsoft-standard` and your are running the script from the base directory of this repository, then it should work out of the box. 
+
+If your sources are elsewhere or you have a different patch set that you want to apply, then you can specify their location(s) with the `-d` and `-p` options, respectively.
+
+You can use the `--dry-run` option to see which patches will be applied without making changes to the kernel source code.
+
+__Example Usage__: 
+```
+scripts/apply_patches.sh
+scripts/apply_patches.sh --dry-run
+scripts/apply_patches.sh -d /usr/src/4.19.43-microsoft-standard
+scripts/apply_patches.sh -d /usr/src/4.19.43-microsoft-standard -p ./patches
+scripts/apply_patches.sh -d /usr/src/my-custon-kernel -p /usr/src/my-custom-patches
+```
+
 Copy USBIP tools libraries to location that USBIP tools can get to them:
 ```
 /usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo cp libsrc/.libs/libusbip.so.0 /lib/libusbip.so.0
-````
+```
 
 Make a script in your home directory to modprobe in all the drivers. Be sure to modprobe in usbcore and usb-common first. I called mine startusb.sh. Mine looks like:
 ```
@@ -196,7 +214,7 @@ Open WSL again by going to start menu and opening Ubuntu and run your script:
 Check in dmesg that all your USB drivers got loaded:
 ```
 ~$ sudo dmesg
-````
+```
 
 If so, cool, you've added USB support to WSL. 
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ Build USBIP tools:
 /usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo make install -j 12
 ```
 
+For some kernel versions the following errors need to be patched:
+1. `stringop-truncation`
+
+    Message:
+    
+        In function ‘strncpy’,
+          inlined from ‘read_usb_vudc_device’ at usbip_device_driver.c:108:2:
+        /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ specified bound 256 equals destination size [-Werror=stringop-truncation]
+        106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
+            |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Patch](https://patchwork.kernel.org/patch/10538575/)
+    
+2. `address-of-packed-member`
+
+    Message:
+    
+        usbip_network.c:91:32: error: taking address of packed member of ‘struct usbip_usb_device’ may result in an unaligned pointer value [-Werror=address-of-packed-member]
+          91 |  usbip_net_pack_uint32_t(pack, &udev->busnum);
+             |                                ^~~~~~~~~~~~~
+    [Patch](https://sources.debian.org/src/linux/5.4.19-1/debian/patches/bugfix/all/usbip-network-fix-unaligned-member-access.patch/)
+
 Copy USBIP tools libraries to location that USBIP tools can get to them:
 ```
 /usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo cp libsrc/.libs/libusbip.so.0 /lib/libusbip.so.0

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Build USBIP tools:
 /usr/src/4.19.43-microsoft-standard/tools/usb/usbip$ sudo make install -j 12
 ```
 
-For some kernel versions the following errors need to be patched:
+New [warnings](https://gcc.gnu.org/gcc-9/changes.html#c-family) were introduced in gcc 9, which can cause the USB/IP build to faild. Their causes can be patched using:
 1. `stringop-truncation`
 
     Message:

--- a/patches/usbip-network-fix-unaligned-member-access.patch
+++ b/patches/usbip-network-fix-unaligned-member-access.patch
@@ -1,0 +1,79 @@
+From: Ben Hutchings <ben@decadent.org.uk>
+Date: Sun, 18 Aug 2019 16:15:26 +0100
+Subject: usbip: network: Fix unaligned member access
+Bug-Debian: https://bugs.debian.org/925766
+
+gcc 9 warns:
+
+usbip_network.c: In function ‘usbip_net_pack_usb_device’:
+usbip_network.c:79:32: error: taking address of packed member of ‘struct usbip_usb_device’ may result in an unaligned pointer value [-Werror=address-of-packed-member]
+   79 |  usbip_net_pack_uint32_t(pack, &udev->busnum);
+      |                                ^~~~~~~~~~~~~
+
+and similarly for other calls to usbip_net_pack_uint{16,32}_t().
+
+These fields are unaligned because they are declared as part of a
+packed structure.  Functions operating on the structure will use the
+appropriate accessors for unaligned data if necessary, but there
+doesn't seem to be a way to declare functions as taking a pointer
+to a unaligned scalar.
+
+Instead, change these functions to take a pointer of type void * and
+to memcpy() the unaligned value in and out of a local variable.
+
+Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
+---
+--- a/tools/usb/usbip/src/usbip_network.c
++++ b/tools/usb/usbip/src/usbip_network.c
+@@ -50,28 +50,30 @@ void usbip_setup_port_number(char *arg)
+ 	info("using port %d (\"%s\")", usbip_port, usbip_port_string);
+ }
+ 
+-void usbip_net_pack_uint32_t(int pack, uint32_t *num)
++void usbip_net_pack_uint32_t(int pack, void *num)
+ {
+ 	uint32_t i;
+ 
++	memcpy(&i, num, sizeof(i));
+ 	if (pack)
+-		i = htonl(*num);
++		i = htonl(i);
+ 	else
+-		i = ntohl(*num);
++		i = ntohl(i);
+ 
+-	*num = i;
++	memcpy(num, &i, sizeof(i));
+ }
+ 
+-void usbip_net_pack_uint16_t(int pack, uint16_t *num)
++void usbip_net_pack_uint16_t(int pack, void *num)
+ {
+ 	uint16_t i;
+ 
++	memcpy(&i, num, sizeof(i));
+ 	if (pack)
+-		i = htons(*num);
++		i = htons(i);
+ 	else
+-		i = ntohs(*num);
++		i = ntohs(i);
+ 
+-	*num = i;
++	memcpy(num, &i, sizeof(i));
+ }
+ 
+ void usbip_net_pack_usb_device(int pack, struct usbip_usb_device *udev)
+--- a/tools/usb/usbip/src/usbip_network.h
++++ b/tools/usb/usbip/src/usbip_network.h
+@@ -166,8 +166,8 @@ struct op_devlist_reply_extra {
+ 	usbip_net_pack_uint32_t(pack, &(reply)->ndev);\
+ } while (0)
+ 
+-void usbip_net_pack_uint32_t(int pack, uint32_t *num);
+-void usbip_net_pack_uint16_t(int pack, uint16_t *num);
++void usbip_net_pack_uint32_t(int pack, void *num);
++void usbip_net_pack_uint16_t(int pack, void *num);
+ void usbip_net_pack_usb_device(int pack, struct usbip_usb_device *udev);
+ void usbip_net_pack_usb_interface(int pack, struct usbip_usb_interface *uinf);
+ 

--- a/patches/usbip-strncpy-stringop-truncation.patch
+++ b/patches/usbip-strncpy-stringop-truncation.patch
@@ -1,0 +1,33 @@
+--- a/tools/usb/usbip/libsrc/usbip_common.c
++++ b/tools/usb/usbip/libsrc/usbip_common.c
+@@ -226,8 +226,8 @@  int read_usb_device(struct udev_device *
+ path = udev_device_get_syspath(sdev);
+ 	name = udev_device_get_sysname(sdev);
+ 
+- strncpy(udev->path,  path,  SYSFS_PATH_MAX);
+- strncpy(udev->busid, name, SYSFS_BUS_ID_SIZE);
++vi-snprintf(udev->path, SYSFS_PATH_MAX, "%s", path);
++vi-snprintf(udev->busid, SYSFS_BUS_ID_SIZE, "%s", name);
+ 
+ 	sscanf(name, "%u-%u", &busnum, &devnum);
+ 	udev->busnum = busnum;
+--- a/tools/usb/usbip/libsrc/usbip_device_driver.c
++++ b/tools/usb/usbip/libsrc/usbip_device_driver.c
+@@ -103,7 +103,7 @@  int read_usb_vudc_device(struct udev_dev
+ copy_descr_attr16(dev, &descr, idProduct);
+ 	copy_descr_attr16(dev, &descr, bcdDevice);
+ 
+- strncpy(dev->path, path, SYSFS_PATH_MAX);
++vi-snprintf(dev->path, SYSFS_PATH_MAX, "%s", path);
+ 
+ 	dev->speed = USB_SPEED_UNKNOWN;
+ 	speed = udev_device_get_sysattr_value(sdev, "current_speed");
+@@ -122,7 +122,7 @@  int read_usb_vudc_device(struct udev_dev
+ dev->busnum = 0;
+ 
+ 	name = udev_device_get_sysname(plat);
+- strncpy(dev->busid, name, SYSFS_BUS_ID_SIZE);
++vi-snprintf(dev->busid, SYSFS_BUS_ID_SIZE, "%s", name);
+ 	return 0;
+ err:
+ 	fclose(fd);

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Default values
+SRC_DIR=(/usr/src/*microsoft-standard)
+PATCH_DIR=./patches
+
+# Other vars
+patches=()
+dry_run=false
+
+function usage() {
+    cat <<EOF
+Usage: $0 [-h|--help] [-d|--directory] [-p|--patches] [--dry-run]
+  -h|--help        This message
+  -d|--directory   Specify the directory of the kernel source code [default: $SRC_DIR]
+  -p|--patches     Specify the directory of the patches to be applied [default: $PATCH_DIR]
+  --dry-run        Find patches, but output only the patch commands that will be used without applying the actual patches [default: false]
+EOF
+}
+
+# Find and store all patches in the given patch directory
+function find_patches() {
+    patches=($PATCH_DIR/*.patch)
+    echo "Found patches: ${patches[@]}"
+}
+
+# Apply all of the found patch files to the specified directory
+function apply_patches() {
+    for patch in "${patches[@]}" ; do
+        echo "Applying patch: $patch"
+        echo "patch -d $SRC_DIR -p1 < $patch"
+        if [ "$dry_run" != true ]; then
+            patch -d $SRC_DIR -p1 < $patch
+        fi
+    done
+}
+
+# Read and apply args (if present)
+function read_args() {
+    local param
+    while [[ $# -gt 0 ]]; do
+        param="$1"
+        shift
+        case $param in
+            -h | --help)
+                usage "$@"
+                exit 0
+                ;;
+            -d | --directory)
+                SRC_DIR=$1
+                shift
+                ;;
+            -p | --patches)
+                PATCH_DIR=$1
+                shift
+                ;;
+            --dry-run)
+                dry_run=true
+                ;;
+            *)
+                echo "Unknown option: $1"
+                usage "$@"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+
+# Main function
+# delegates to subroutines
+function main() {
+    read_args "$@"
+    find_patches
+    apply_patches
+    exit 0
+}
+
+
+# run
+main "$@"


### PR DESCRIPTION
For some kernel versions USB/IP may require a patch in order to compile. These are fixed in current kernel versions, but some may not have the patches in their version.

Added information for these patches: stringop-trunctation in usbip_device_driver.c, and address-of-packed-member in usbip_network.c